### PR TITLE
Some code and package cleanup, and add support for Webpack 4

### DIFF
--- a/change/cpupro-webpack-plugin-4afd3094-e243-45c2-a7cd-3cd90efc43ca.json
+++ b/change/cpupro-webpack-plugin-4afd3094-e243-45c2-a7cd-3cd90efc43ca.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add support for Webpack 4 and publish TypeScript declarations.",
+  "packageName": "cpupro-webpack-plugin",
+  "email": "iclanton@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -2,16 +2,30 @@
   "name": "cpupro-webpack-plugin",
   "version": "1.1.0",
   "main": "lib/index.js",
+  "typings": "lib/index.d.ts",
   "license": "MIT",
+  "peerDependencies": {
+    "@types/webpack": "*"
+  },
+  "peerDependenciesMeta": {
+    "@types/webpack": {
+      "optional": true
+    }
+  },
   "devDependencies": {
-    "typescript": "^4.6.2",
+    "@types/node": "^14.18.13",
     "@types/webpack": "^5.28.0",
-    "beachball": "^2.16.0"
+    "@types/webpack4": "npm:@types/webpack@^4.41.32",
+    "beachball": "^2.16.0",
+    "typescript": "^4.6.2"
   },
   "scripts": {
     "build": "tsc",
     "start": "tsc -w --preserveWatchOutput",
     "change": "beachball change -b origin/main",
     "release": "yarn build && beachball publish -b origin/main"
-  }
+  },
+  "files": [
+    "lib/**/*"
+  ]
 }

--- a/src/CPUProfileWebpackPlugin.ts
+++ b/src/CPUProfileWebpackPlugin.ts
@@ -1,4 +1,5 @@
-import { Compiler } from "webpack";
+import type { Compiler as WebpackCompiler } from "webpack";
+import type { Compiler as Webpack4Compiler } from "webpack4";
 import path from "path";
 import { promisify } from "util";
 import inspector from "inspector";
@@ -11,47 +12,78 @@ export interface CPUProfileWebpackPluginOptions {
 const PluginName = "CPUProfileWebpackPlugin";
 
 export class CPUProfileWebpackPlugin {
-  private session: inspector.Session;
-  private profileName: string;
+  private readonly session: inspector.Session;
+  private readonly profileName: string;
 
-  constructor(private options: CPUProfileWebpackPluginOptions = {}) {
+  constructor(private readonly options: CPUProfileWebpackPluginOptions = {}) {
     this.session = new inspector.Session();
     this.session.connect();
     this.profileName = options.profileName ?? "webpack";
   }
 
-  apply(compiler: Compiler): void {
-    const fs = compiler.intermediateFileSystem;
-    const writeFile = promisify(fs.writeFile);
-    const logger = compiler.getInfrastructureLogger(PluginName);
+  apply(compiler: WebpackCompiler): void {
+    const webpackCompiler: Webpack4Compiler | WebpackCompiler = compiler as
+      | Webpack4Compiler
+      | WebpackCompiler;
 
-    if (!this.options.outputPath) {
-      this.options.outputPath = path.resolve(compiler.options.output.path, "webpack.cpuprofile");
+    const fs = webpackCompiler.outputFileSystem;
+    const writeFile = promisify(fs.writeFile);
+    const logger = webpackCompiler.getInfrastructureLogger(PluginName);
+
+    let outputPath: string | undefined = this.options.outputPath;
+    if (!outputPath) {
+      const compilationOutputPath: string | undefined =
+        webpackCompiler.options.output?.path;
+      if (!compilationOutputPath) {
+        throw new Error(
+          `If an explicit "outputPath" is not passed to the ${CPUProfileWebpackPlugin.name} plugin's ` +
+            "constructor's options object, the output.path property must be set in the webpack configuration."
+        );
+      }
+
+      outputPath = path.resolve(compilationOutputPath, "webpack.cpuprofile");
     }
 
     // Start profiling as soon as this plugin is applied
     logger.info(`Starting CPU Profile: ${this.profileName}`);
-    const cpuProfilerEnable = promisify(this.session.post.bind(this.session, "Profiler.enable"));
-    const cpuProfilerStart = promisify(this.session.post.bind(this.session, "Profiler.start"));
-    const cpuProfilerStop = promisify(this.session.post.bind(this.session, "Profiler.stop"));
+    const cpuProfilerEnable = promisify(
+      this.session.post.bind<inspector.Session, "Profiler.enable", never, void>(
+        this.session,
+        "Profiler.enable"
+      )
+    );
+    const cpuProfilerStart = promisify(
+      this.session.post.bind<inspector.Session, "Profiler.start", never, void>(
+        this.session,
+        "Profiler.start"
+      )
+    );
+    const cpuProfilerStop = promisify(
+      this.session.post.bind<
+        inspector.Session,
+        "Profiler.stop",
+        never,
+        inspector.Profiler.StopReturnType | void
+      >(this.session, "Profiler.stop")
+    );
 
     const profileStartPromise = cpuProfilerEnable().then(() => {
       return cpuProfilerStart();
     });
 
     // Stop profiling when the entire webpack run is done
-    compiler.hooks.done.tapPromise(PluginName, async (_stats) => {
+    webpackCompiler.hooks.done.tapPromise(PluginName, async () => {
       await profileStartPromise;
 
-      const { outputPath } = this.options;
       try {
-        const profile = await cpuProfilerStop();
+        const profile =
+          (await cpuProfilerStop()) as inspector.Profiler.StopReturnType;
 
-        if (!profile) { 
+        if (!profile) {
           throw new Error("output did not contain profile information");
         }
-        
-        await writeFile(outputPath, JSON.stringify(profile.profile));
+
+        await writeFile(outputPath!, JSON.stringify(profile.profile));
         logger.info(`CPU Profile written to: ${outputPath}`);
       } catch (e) {
         logger.error(`CPU Profile plugine encountered an error: ${e}`);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,11 +2,15 @@
   "compilerOptions": {
     "module": "CommonJS",
     "target": "ES2019",
-    "allowJs": true,
-    "noImplicitAny": false,
+    "strict": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "outDir": "lib"
+    "declaration": true,
+    "declarationMap": true,
+    "declarationDir": "lib",
+    "outDir": "lib",
+    "types": ["node"],
+    "skipLibCheck": true // We're using both the webpack 4 and webpack 5 typings, which conflict
   },
   "include": ["src"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -80,10 +80,53 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.22.tgz#38b6c4b9b2f3ed9f2e376cce42a298fb2375251e"
   integrity sha512-8FwbVoG4fy+ykY86XCAclKZDORttqE5/s7dyWZKLXTdv3vRy5HozBEinG5IqhvPXXzIZEcTVbuHlQEI6iuwcmw==
 
+"@types/node@^14.18.13":
+  version "14.18.13"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.13.tgz#6ad4d9db59e6b3faf98dcfe4ca9d2aec84443277"
+  integrity sha512-Z6/KzgyWOga3pJNS42A+zayjhPbf2zM3hegRQaOPnLOzEi86VV++6FLDWgR1LGrVCRufP/ph2daa3tEa5br1zA==
+
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
+
+"@types/source-list-map@*":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@types/source-list-map/-/source-list-map-0.1.2.tgz#0078836063ffaf17412349bba364087e0ac02ec9"
+  integrity sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==
+
+"@types/tapable@^1":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.8.tgz#b94a4391c85666c7b73299fd3ad79d4faa435310"
+  integrity sha512-ipixuVrh2OdNmauvtT51o3d8z12p6LtFW9in7U79der/kwejjdNchQC5UMn5u/KxNoM7VHHOs/l8KS8uHxhODQ==
+
+"@types/uglify-js@*":
+  version "3.13.2"
+  resolved "https://registry.yarnpkg.com/@types/uglify-js/-/uglify-js-3.13.2.tgz#1044c1713fb81cb1ceef29ad8a9ee1ce08d690ef"
+  integrity sha512-/xFrPIo+4zOeNGtVMbf9rUm0N+i4pDf1ynExomqtokIJmVzR3962lJ1UE+MmexMkA0cmN9oTzg5Xcbwge0Ij2Q==
+  dependencies:
+    source-map "^0.6.1"
+
+"@types/webpack-sources@*":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@types/webpack-sources/-/webpack-sources-3.2.0.tgz#16d759ba096c289034b26553d2df1bf45248d38b"
+  integrity sha512-Ft7YH3lEVRQ6ls8k4Ff1oB4jN6oy/XmU6tQISKdhfh+1mR+viZFphS6WL0IrtDOzvefmJg5a0s7ZQoRXwqTEFg==
+  dependencies:
+    "@types/node" "*"
+    "@types/source-list-map" "*"
+    source-map "^0.7.3"
+
+"@types/webpack4@npm:@types/webpack@^4.41.32":
+  version "4.41.32"
+  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.32.tgz#a7bab03b72904070162b2f169415492209e94212"
+  integrity sha512-cb+0ioil/7oz5//7tZUSwbrSAN/NWHrQylz5cW8G0dWTcF/g+/dSdMlKVZspBYuMAN1+WnwHrkxiRrLcwd0Heg==
+  dependencies:
+    "@types/node" "*"
+    "@types/tapable" "^1"
+    "@types/uglify-js" "*"
+    "@types/webpack-sources" "*"
+    anymatch "^3.0.0"
+    source-map "^0.6.0"
 
 "@types/webpack@^5.28.0":
   version "5.28.0"
@@ -261,6 +304,14 @@ ansi-styles@^3.2.1:
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
   dependencies:
     color-convert "^1.9.0"
+
+anymatch@^3.0.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.2.tgz#c0557c096af32f106198f4f4e2a383537e378716"
+  integrity sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==
+  dependencies:
+    normalize-path "^3.0.0"
+    picomatch "^2.0.4"
 
 argparse@^2.0.1:
   version "2.0.1"
@@ -1342,6 +1393,11 @@ node-releases@^2.0.2:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.2.tgz#7139fe71e2f4f11b47d4d2986aaf8c48699e0c01"
   integrity sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==
 
+normalize-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
+  integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
+
 normalize-url@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-6.1.0.tgz#40d0885b535deffe3f3147bec877d05fe4c5668a"
@@ -1489,7 +1545,7 @@ picocolors@^1.0.0:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
-picomatch@^2.2.3:
+picomatch@^2.0.4, picomatch@^2.2.3:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
@@ -1750,7 +1806,7 @@ source-map@^0.6.0, source-map@^0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-source-map@~0.7.2:
+source-map@^0.7.3, source-map@~0.7.2:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==


### PR DESCRIPTION
This PR changes a few things:

- Enables `"strict"` in `tsconfig.json` and fixes the new issues
- Enables generation of TypeScript declarations
- Includes a `"typings"` field in `package.json`, pointing to `lib/index.d.ts`
- Filters out the `src` folder from the published package
- Adds typechecking against the Webpack 4 typings and fixes compatibility issues with Webpack 4.